### PR TITLE
Fix versions naming, add more tags

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -23,9 +23,10 @@ on:
       - '3.11-bullseye.Dockerfile'
       - './github/workflows/docker.yml'
 env:
-  MYPY_VERSION: '1.11.1'
-  PYTHON_VERSION_MAJOR: '3.11'
-  PYTHON_VERSION_MINOR: '9'
+  MYPY_VERSION_MINOR: '1.11'
+  MYPY_VERSION_PATCH: '1'
+  PYTHON_VERSION_MINOR: '3.11'
+  PYTHON_VERSION_PATCH: '9'
   DEBIAN_VERSION: 'bullseye'
   DOCKERHUB_REPO: ${{ vars.DOCKERHUB_USERNAME }}/mypy
   GHCR_REPO: ghcr.io/${{ github.repository }}
@@ -46,7 +47,7 @@ jobs:
         with:
           push: false
           load: true
-          file: ${{ env.PYTHON_VERSION_MAJOR }}-${{ env.DEBIAN_VERSION }}.Dockerfile
+          file: ${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }}.Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: ${{ env.DOCKERHUB_REPO }}:latest
@@ -87,19 +88,29 @@ jobs:
         uses: docker/build-push-action@4f7cdeb0f05278b464e71357394bf2c61f94138e # 6.6.0
         with:
           push: true
-          file: ${{ env.PYTHON_VERSION_MAJOR }}-${{ env.DEBIAN_VERSION }}.Dockerfile
+          file: ${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }}.Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           platforms: linux/amd64
           tags: >-
             ${{ env.DOCKERHUB_REPO }}:latest,
-            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION }},
-            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }},
-            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.DEBIAN_VERSION }},
-            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }},
-            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }},
+            ${{ env.DOCKERHUB_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }}-${{ env.DEBIAN_VERSION }},
             ${{ env.GHCR_REPO }}:latest,
-            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION }},
-            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }},
-            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}-${{ env.DEBIAN_VERSION }},
-            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }},
-            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION }}-py${{ env.PYTHON_VERSION_MAJOR }}.${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}-${{ env.DEBIAN_VERSION }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }},
+            ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION_MINOR }}.${{ env.PYTHON_VERSION_PATCH }}-${{ env.DEBIAN_VERSION }},

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -21,7 +21,7 @@ on:
       - reopened
     paths:
       - '3.11-bullseye.Dockerfile'
-      - './github/workflows/docker.yml'
+      - './github/workflows/docker_image.yml'
 env:
   MYPY_VERSION_MINOR: '1.11'
   MYPY_VERSION_PATCH: '1'


### PR DESCRIPTION
Fixes naming of version components that were incorrectly called MAJOR and MINOR. These labels actually refer to MINOR and PATCH components respectively.

Also adds more granular tags, so that one can track all releases in mypy's minor version without having to specify patch component.