### PR TITLE
Fix copyright headers in GH Actions files

### DIFF
--- a/.github/workflows/docker-py3.11.yml
+++ b/.github/workflows/docker-py3.11.yml
@@ -1,5 +1,5 @@
-# docker-pypa-build - Docker configuration for PyPA's build
-# Written in 2024 by Hubert Bielenia <13271065+hbielenia@users.noreply.github.com>
+# docker-mypy - Docker configuration for mypy
+# Written in 2024 by Hubert Bielenia <hbielenia@users.noreply.github.com>
 # To the extent possible under law, the author(s) have dedicated all copyright and related
 # and neighboring rights to this software to the public domain worldwide. This software
 # is distributed without any warranty.

--- a/.github/workflows/docker-py3.12.yml
+++ b/.github/workflows/docker-py3.12.yml
@@ -1,5 +1,5 @@
-# docker-pypa-build - Docker configuration for PyPA's build
-# Written in 2024 by Hubert Bielenia <13271065+hbielenia@users.noreply.github.com>
+# docker-mypy - Docker configuration for mypy
+# Written in 2024 by Hubert Bielenia <hbielenia@users.noreply.github.com>
 # To the extent possible under law, the author(s) have dedicated all copyright and related
 # and neighboring rights to this software to the public domain worldwide. This software
 # is distributed without any warranty.


### PR DESCRIPTION
Fixes the copyright header content (project name and author's email) in some GitHub Actions workflow files. These were wrong due to hasty copypasting from another project.