### PR TITLE
Update docker-build-action to 0.2.4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Build Docker image
-        uses: hbielenia/docker-build-action@dfa079645a47a1ba3d4323ec3f5aa4ad8ed8f003 # 0.2.2
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ env.DEBIAN_VERSION }}/python-${{ env.PYTHON_VERSION }}.Dockerfile
           tags: ${{ env.DOCKERHUB_REPO }}:latest
@@ -60,7 +60,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker image
-        uses: hbielenia/docker-build-action@dfa079645a47a1ba3d4323ec3f5aa4ad8ed8f003 # 0.2.2
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ env.DEBIAN_VERSION }}/python-${{ env.PYTHON_VERSION }}.Dockerfile
           from_cache: '1'
@@ -84,7 +84,7 @@ jobs:
             ${{ env.GHCR_REPO }}:${{ env.MYPY_VERSION_MINOR }}.${{ env.MYPY_VERSION_PATCH }}-py${{ env.PYTHON_VERSION }}.${{ inputs.python_version_patch  }}-${{ env.DEBIAN_VERSION }},
       - name: Push generic tags
         if: inputs.latest
-        uses: hbielenia/docker-build-action@dfa079645a47a1ba3d4323ec3f5aa4ad8ed8f003 # 0.2.2
+        uses: hbielenia/docker-build-action@2dd2f6d3d269aa3e95e4ac232d2714c1c67453a0 # 0.2.4
         with:
           dockerfile: ./dockerfiles/${{ env.DEBIAN_VERSION }}/python-${{ env.PYTHON_VERSION }}.Dockerfile
           from_cache: '1'


### PR DESCRIPTION
Updates the docker-build-action dependency to v. 0.2.4, released on 2025-04-08.