### PR TITLE
Update mypy to v. 1.16.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # docker-mypy - Docker configuration for PyPA's build
-# Written in 2024 by Hubert Bielenia <hbielenia@users.noreply.github.com>
+# Written in 2025 by Hubert Bielenia <hbielenia@users.noreply.github.com>
 # To the extent possible under law, the author(s) have dedicated all copyright and related
 # and neighboring rights to this software to the public domain worldwide. This software
 # is distributed without any warranty.
@@ -26,7 +26,7 @@ on:
         type: number
         required: true
 env:
-  MYPY_VERSION_MINOR: '1.15'
+  MYPY_VERSION_MINOR: '1.16'
   MYPY_VERSION_PATCH: '0'
   PYTHON_VERSION: '${{ inputs.python_version_major }}.${{ inputs.python_version_minor }}'
   DEBIAN_VERSION: bullseye

--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,16 @@ Images
 ======
 The currently built images are:
 
-- ``1.15-py3.13``, also tagged ``1.15-py3.13-bullseye``, ``1.15-py3.13.0``,
-  ``1.15-py3.13.0-bullseye``, ``1.15.0-py3.13``, ``1.15.0-py3.13-bullseye``,
-  ``1.15.0-py3.13.0`` and ``1.15.0-py3.13.0-bullseye``.
-- ``1.15-py3.12``, also tagged ``1.15-py3.12-bullseye``, ``1.15-py3.12.7``,
-  ``1.15-py3.12.7-bullseye``, ``1.15.0-py3.12``, ``1.15.0-py3.12-bullseye``,
-  ``1.15.0-py3.12.7``, ``1.15.0-py3.12.7-bullseye``, ``1.15.0``, ``1.15``
-  and `latest``.
-- ``1.15-py3.11``, also tagged ``1.15-py3.11-bullseye``, ``1.15-py3.11.10``,
-  ``1.15-py3.11.10-bullseye``, ``1.15.0-py3.11``, ``1.15.0-py3.11-bullseye``,
-  ``1.15.0-py3.11.10`` and ``1.15.0-py3.11.10-bullseye``.
+- ``1.16-py3.13``, also tagged ``1.16-py3.13-bullseye``, ``1.16-py3.13.0``,
+  ``1.16-py3.13.0-bullseye``, ``1.16.0-py3.13``, ``1.16.0-py3.13-bullseye``,
+  ``1.16.0-py3.13.0`` and ``1.16.0-py3.13.0-bullseye``.
+- ``1.16-py3.12``, also tagged ``1.16-py3.12-bullseye``, ``1.16-py3.12.7``,
+  ``1.16-py3.12.7-bullseye``, ``1.16.0-py3.12``, ``1.16.0-py3.12-bullseye``,
+  ``1.16.0-py3.12.7``, ``1.16.0-py3.12.7-bullseye``, ``1.16.0``, ``1.16``
+  and ``latest``.
+- ``1.16-py3.11``, also tagged ``1.16-py3.11-bullseye``, ``1.16-py3.11.10``,
+  ``1.16-py3.11.10-bullseye``, ``1.16.0-py3.11``, ``1.16.0-py3.11-bullseye``,
+  ``1.16.0-py3.11.10`` and ``1.16.0-py3.11.10-bullseye``.
 
 Usage
 =====

--- a/dockerfiles/bullseye/python-3.11.Dockerfile
+++ b/dockerfiles/bullseye/python-3.11.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.11-bullseye@sha256:4cbbc6b1984dce78ef73e22649423bac56394e9d2eeb7c233c4113aa811b8b6f
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9397454fb5aead107461b089e7cf190bf538d20a
+RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
 CMD [ "mypy" ]

--- a/dockerfiles/bullseye/python-3.12.Dockerfile
+++ b/dockerfiles/bullseye/python-3.12.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.12-bullseye@sha256:f6d639b794b394cbeb7a9327d5af9976f0e8d61353bcf41916984775c9bbed1a
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9397454fb5aead107461b089e7cf190bf538d20a
+RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
 CMD [ "mypy" ]

--- a/dockerfiles/bullseye/python-3.13.Dockerfile
+++ b/dockerfiles/bullseye/python-3.13.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.13-bullseye@sha256:7ab8844f3427d44da3eec7f63a078cc6bf60127bb632418e1fad18569199a25d
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9397454fb5aead107461b089e7cf190bf538d20a
+RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
 CMD [ "mypy" ]


### PR DESCRIPTION
Updates mypy to version 1.16.0, released on 2025-05-29.