### PR TITLE
Update mypy to v. 1.16.1

### DIFF
--- a/.github/workflows/docker-py3.11.yml
+++ b/.github/workflows/docker-py3.11.yml
@@ -31,5 +31,5 @@ jobs:
     secrets: inherit
     with:
       python_version_minor: 11
-      python_version_patch: 10
+      python_version_patch: 13
       push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker-py3.12.yml
+++ b/.github/workflows/docker-py3.12.yml
@@ -32,5 +32,5 @@ jobs:
     with:
       latest: true
       python_version_minor: 12
-      python_version_patch: 7
+      python_version_patch: 11
       push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker-py3.13.yml
+++ b/.github/workflows/docker-py3.13.yml
@@ -31,5 +31,5 @@ jobs:
     secrets: inherit
     with:
       python_version_minor: 13
-      python_version_patch: 0
+      python_version_patch: 5
       push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ on:
         required: true
 env:
   MYPY_VERSION_MINOR: '1.16'
-  MYPY_VERSION_PATCH: '0'
+  MYPY_VERSION_PATCH: '1'
   PYTHON_VERSION: '${{ inputs.python_version_major }}.${{ inputs.python_version_minor }}'
   DEBIAN_VERSION: bullseye
   DOCKERHUB_REPO: ${{ vars.DOCKERHUB_USERNAME }}/mypy

--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,16 @@ Images
 ======
 The currently built images are:
 
-- ``1.16-py3.13``, also tagged ``1.16-py3.13-bullseye``, ``1.16-py3.13.0``,
-  ``1.16-py3.13.0-bullseye``, ``1.16.0-py3.13``, ``1.16.0-py3.13-bullseye``,
-  ``1.16.0-py3.13.0`` and ``1.16.0-py3.13.0-bullseye``.
-- ``1.16-py3.12``, also tagged ``1.16-py3.12-bullseye``, ``1.16-py3.12.7``,
-  ``1.16-py3.12.7-bullseye``, ``1.16.0-py3.12``, ``1.16.0-py3.12-bullseye``,
-  ``1.16.0-py3.12.7``, ``1.16.0-py3.12.7-bullseye``, ``1.16.0``, ``1.16``
+- ``1.16-py3.13``, also tagged ``1.16-py3.13-bullseye``, ``1.16-py3.13.5``,
+  ``1.16-py3.13.5-bullseye``, ``1.16.1-py3.13``, ``1.16.1-py3.13-bullseye``,
+  ``1.16.1-py3.13.5`` and ``1.16.1-py3.13.5-bullseye``.
+- ``1.16-py3.12``, also tagged ``1.16-py3.12-bullseye``, ``1.16-py3.12.11``,
+  ``1.16-py3.12.11-bullseye``, ``1.16.1-py3.12``, ``1.16.1-py3.12-bullseye``,
+  ``1.16.1-py3.12.11``, ``1.16.1-py3.12.11-bullseye``, ``1.16.1``, ``1.16``
   and ``latest``.
-- ``1.16-py3.11``, also tagged ``1.16-py3.11-bullseye``, ``1.16-py3.11.10``,
-  ``1.16-py3.11.10-bullseye``, ``1.16.0-py3.11``, ``1.16.0-py3.11-bullseye``,
-  ``1.16.0-py3.11.10`` and ``1.16.0-py3.11.10-bullseye``.
+- ``1.16-py3.11``, also tagged ``1.16-py3.11-bullseye``, ``1.16-py3.11.13``,
+  ``1.16-py3.11.13-bullseye``, ``1.16.1-py3.11``, ``1.16.1-py3.11-bullseye``,
+  ``1.16.1-py3.11.13`` and ``1.16.1-py3.11.13-bullseye``.
 
 Usage
 =====

--- a/dockerfiles/bullseye/python-3.11.Dockerfile
+++ b/dockerfiles/bullseye/python-3.11.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.11-bullseye@sha256:4cbbc6b1984dce78ef73e22649423bac56394e9d2eeb7c233c4113aa811b8b6f
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
+RUN python -m pip install git+https://github.com/python/mypy.git@68b8fa097d080c92d30a429bc74de8acd56caf85
 CMD [ "mypy" ]

--- a/dockerfiles/bullseye/python-3.12.Dockerfile
+++ b/dockerfiles/bullseye/python-3.12.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.12-bullseye@sha256:f6d639b794b394cbeb7a9327d5af9976f0e8d61353bcf41916984775c9bbed1a
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
+RUN python -m pip install git+https://github.com/python/mypy.git@68b8fa097d080c92d30a429bc74de8acd56caf85
 CMD [ "mypy" ]

--- a/dockerfiles/bullseye/python-3.13.Dockerfile
+++ b/dockerfiles/bullseye/python-3.13.Dockerfile
@@ -10,5 +10,5 @@
 
 FROM python:3.13-bullseye@sha256:7ab8844f3427d44da3eec7f63a078cc6bf60127bb632418e1fad18569199a25d
 WORKDIR /usr/src/app
-RUN python -m pip install git+https://github.com/python/mypy.git@9e72e9601f4c2fb6866cfec98fc40a31c91ccdb0
+RUN python -m pip install git+https://github.com/python/mypy.git@68b8fa097d080c92d30a429bc74de8acd56caf85
 CMD [ "mypy" ]


### PR DESCRIPTION
Updates mypy to version 1.16.1, released on 2025-06-11. Also fixes the Python version numbers.